### PR TITLE
Fix unused IMGUIZEP_ROOT define causing C2220 and C5102 error

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -89,9 +89,6 @@ ly_add_target(
         ${pal_dir}/imguizep_private_files.cmake
     TARGET_PROPERTIES
         O3DE_PRIVATE_TARGET TRUE
-    COMPILE_DEFINITIONS
-        PRIVATE
-            IMGUIZEP_ROOT ${CMAKE_CURRENT_LIST_DIR}
     INCLUDE_DIRECTORIES
         PRIVATE
             Include


### PR DESCRIPTION
Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>